### PR TITLE
Do not check for timeout too often

### DIFF
--- a/Linux/src/search.cpp
+++ b/Linux/src/search.cpp
@@ -242,7 +242,7 @@ namespace Search {
 	    		searched_moves++;
 	        	pos.undo_move();
 	    		// Return if timeout
-	    		if (search_info.nodes & 2047) {
+	    		if ((search_info.nodes & 2047) == 0) {
 	    			if (Time::time_out(search_info.start_time, search_info.time_to_search) || search_info.stop)
 	    				return -1;
 	    		}
@@ -351,7 +351,7 @@ namespace Search {
 	    		int score = -quiescence_search(pos, -beta, -alpha, search_info);
 	    		pos.undo_move();
 	    		// Return if timeout
-	    		if (search_info.nodes & 2047) {
+	    		if ((search_info.nodes & 2047) == 0) {
 	    			if (Time::time_out(search_info.start_time, search_info.time_to_search) || search_info.stop)
 	    				return -1;
 	    		}

--- a/Windows/src/search.cpp
+++ b/Windows/src/search.cpp
@@ -242,7 +242,7 @@ namespace Search {
 	    		searched_moves++;
 	        	pos.undo_move();
 	    		// Return if timeout
-	    		if (search_info.nodes & 2047) {
+	    		if ((search_info.nodes & 2047) == 0) {
 	    			if (Time::time_out(search_info.start_time, search_info.time_to_search) || search_info.stop)
 	    				return -1;
 	    		}
@@ -351,7 +351,7 @@ namespace Search {
 	    		int score = -quiescence_search(pos, -beta, -alpha, search_info);
 	    		pos.undo_move();
 	    		// Return if timeout
-	    		if (search_info.nodes & 2047) {
+	    		if ((search_info.nodes & 2047) == 0) {
 	    			if (Time::time_out(search_info.start_time, search_info.time_to_search) || search_info.stop)
 	    				return -1;
 	    		}


### PR DESCRIPTION
Due to a bug, `Time::time_out()` is called on (almost) each node instead of each `2048`th node. This may lead to degraded performance because checking the system clock may take much time.

This PR fixes the bug, which may improve search speed on some systems.